### PR TITLE
fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ int main(int argc, const char * argv[]) {
 ```
 ###### Chunks
 
-A [chunk](http://en.wikipedia.org/wiki/Chunk_(information) is a fragment of JSON. JsonLite ObjC allows you to process a chunk while other parts of JSON are delivering by network. 'Chunk Oriented' processing style allow developer to improve memory usage and increase program performance, also its' provide ability to work with huge JSON data.
+A [chunk] is a fragment of JSON. JsonLite ObjC allows you to process a chunk while other parts of JSON are delivering by network. 'Chunk Oriented' processing style allow developer to improve memory usage and increase program performance, also its' provide ability to work with huge JSON data.
+
+  [chunk]: http://en.wikipedia.org/wiki/Chunk_(information)  "Chunk (information) - Wikipedia, the free encyclopedia"
 
 Also this example shows full parsing flow: create parser -> assign delegate -> parse data. 
 


### PR DESCRIPTION
Hi, I found broken link in README , because `)` character is missing.

Additionally, Github's Markdown does't handling URL containing parentheses `()`, so use alt link format.

ref. http://meta.stackoverflow.com/questions/13501/links-to-urls-containing-parentheses

thanks.
